### PR TITLE
Replace gureum.org with gureum.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@ article h1 { font-size: 150%; font-weight: bold; }
 <article id="install">
 <span class="totop"><a href="#header">⇧</a></span>
 <h1>설치하기</h1>
-<p><span id="download-link"></span><a href="http://bi.gureum.org/">내려받기 페이지</a>에서 안정버전이나 실험버전 가운데 하나를 골라 내려받을 수 있습니다. 처음 설치해 보거나 설치를 했는데 이용에 문제가 있다면 <a href="https://github.com/gureum/gureum/wiki/Help-Install">설치하기 도움말</a>을 확인해 보세요.</p>
+<p><span id="download-link"></span><a href="http://bi.gureum.io/">내려받기 페이지</a>에서 안정버전이나 실험버전 가운데 하나를 골라 내려받을 수 있습니다. 처음 설치해 보거나 설치를 했는데 이용에 문제가 있다면 <a href="https://github.com/gureum/gureum/wiki/Help-Install">설치하기 도움말</a>을 확인해 보세요.</p>
 <p>※ 설치했는데 어떻게 쓰는 지 모르겠다면, <a href="https://github.com/gureum/gureum/wiki/Help-Install">설치하기 도움말</a>을 보고 설정을 따라해 주세요. 설정 단계를 거쳐야만 쓰기 시작할 수 있습니다!</p>
 </article>
 
@@ -138,7 +138,7 @@ article h1 { font-size: 150%; font-weight: bold; }
 <span class="totop"><a href="#header">⇧</a></span>
 <h1>버그 신고</h1>
 <p>구름에는 아직 많은 버그가 있습니다. 알려주시면 구름이 더 나아지는데 많은 도움이 됩니다.
-버그 신고는 <a href="http://meok.gureum.org/">프로젝트 이슈 페이지</a>에서 할 수 있습니다.</p>
+버그 신고는 <a href="http://meok.gureum.io/">프로젝트 이슈 페이지</a>에서 할 수 있습니다.</p>
 <p>github 계정이 없다면 계정을 만들어야만 글을 쓸 수 있습니다. 신고한 버그에 변경사항이 생기거나 해결이 되면 github 가입에 쓴 이메일 주소로 알림을 받아볼 수 있습니다.</p>
 </article>
 
@@ -146,7 +146,7 @@ article h1 { font-size: 150%; font-weight: bold; }
 <span class="totop"><a href="#header">⇧</a></span>
 <h1>소스코드와 라이선스</h1>
 <ul>
-  <li>소스코드: <a href="http://ssi.gureum.org">ssi.gureum.org</a></li>
+  <li>소스코드: <a href="http://ssi.gureum.io">ssi.gureum.io</a></li>
   <li>관련 소스코드: <a href="https://github.com/gureum/">github.com/gureum</a></li>
   <li>프론트엔드는 <a class="box" href="https://github.com/gureum/gureum/blob/master/COPYING">2-clause BSD</a>로 배포됩니다.</li>
   <li>백엔드는 <a href="https://github.com/libhangul/libhangul">libhangul</a>의 <a href="https://github.com/gureum/libhangul-objc/">Objective-C 인터페이스</a>이며 둘 모두 <a class="box" href="https://github.com/gureum/libhangul-objc/blob/master/COPYING">LGPL</a>로 배포됩니다</li>


### PR DESCRIPTION
바뀐 URL도 모두 동작하는 것을 확인했습니다. 이 저장소의 링크도 gureum.io로 바꿀 수 있겠습니다.